### PR TITLE
fix(popover): avoid SwiftUI ProgressView constraint assertion

### DIFF
--- a/ClaudeMeter/Views/MenuBar/UsagePopoverView.swift
+++ b/ClaudeMeter/Views/MenuBar/UsagePopoverView.swift
@@ -31,9 +31,11 @@ struct UsagePopoverView: View {
                     }
                 }) {
                     if appModel.isRefreshing {
+                        // Use controlSize rather than scaleEffect+frame: combining the latter on
+                        // an AppKit-backed ProgressView produces a SwiftUI runtime constraint
+                        // assertion ("max <= min" failing on equal floats) on macOS.
                         ProgressView()
-                            .scaleEffect(0.7)
-                            .frame(width: 20, height: 20)
+                            .controlSize(.small)
                     } else {
                         Image(systemName: "arrow.clockwise")
                     }


### PR DESCRIPTION
## Summary

The refresh button in the usage popover composes `ProgressView().scaleEffect(0.7).frame(width: 20, height: 20)`. On macOS this triggers a SwiftUI runtime assertion when the button enters the refreshing state:

```
<_TtGC7SwiftUI22AppKitPlatformViewHostGVS_P10$1bc60db8432PlatformViewRepresentableAdaptorVS_18AppKitProgressView__: 0xace0a8a80>
has an maximum length (32.142857) that doesn't satisfy min (32.142857) <= max (32.142857).
```

The min and max are *identical* values (≈ `225/7`), but SwiftUI's strict floating-point comparison still rejects them. The cause: AppKit's `NSProgressIndicator` returns an intrinsic content size that's a non-terminating decimal, and feeding it back through `scaleEffect` + `frame` produces values that fail bitwise equality.

## The fix

Replace the `scaleEffect(0.7) + frame(20, 20)` combo with `controlSize(.small)`. This is the macOS-native way to ask for a smaller spinner and skips the conflicting size constraints — same visual reduction, no runtime assertion, fewer modifiers.

## Test plan
- [ ] Click the refresh button in the usage popover; the small spinner appears with no console warnings.
- [ ] The spinner is visually similar to the previous 14×14 rendering (small control size).
- [ ] No regression in the surrounding `arrow.clockwise` icon when the popover is idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)