### PR TITLE
fix: handle null usage resets and spinner sizing

### DIFF
--- a/ClaudeMeter/Models/API/UsageAPIResponse.swift
+++ b/ClaudeMeter/Models/API/UsageAPIResponse.swift
@@ -49,38 +49,30 @@ enum MappingError: LocalizedError {
 /// Extension to map API response to domain model
 extension UsageAPIResponse {
     func toDomain() throws -> UsageData {
-        // Configure ISO8601 formatter with proper options
         let iso8601Formatter = ISO8601DateFormatter()
         iso8601Formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
-        // Parse reset dates (must be present and valid)
-        let sessionResetDate: Date
-        let weeklyResetDate: Date
-
-        guard let sessionResetString = fiveHour.resetsAt,
-              let parsedDate = iso8601Formatter.date(from: sessionResetString) else {
-            throw MappingError.missingCriticalField(field: "fiveHour.resetsAt")
-        }
-        sessionResetDate = parsedDate
-
-        guard let weeklyResetString = sevenDay.resetsAt,
-              let parsedDate = iso8601Formatter.date(from: weeklyResetString) else {
-            throw MappingError.missingCriticalField(field: "sevenDay.resetsAt")
-        }
-        weeklyResetDate = parsedDate
+        let sessionResetDate = try parseResetDate(
+            from: fiveHour.resetsAt,
+            field: "fiveHour.resetsAt",
+            formatter: iso8601Formatter,
+            fallback: Constants.Pacing.sessionWindow
+        )
+        let weeklyResetDate = try parseResetDate(
+            from: sevenDay.resetsAt,
+            field: "sevenDay.resetsAt",
+            formatter: iso8601Formatter,
+            fallback: Constants.Pacing.weeklyWindow
+        )
 
         // Handle optional sonnet usage
-        let sonnetLimit: UsageLimit? = sevenDaySonnet.flatMap { sonnet in
-            let sonnetResetDate: Date
-
-            if let sonnetResetString = sonnet.resetsAt,
-               let parsedDate = iso8601Formatter.date(from: sonnetResetString) {
-                sonnetResetDate = parsedDate
-            } else {
-                // Default to 7 days in the future if no reset date
-                sonnetResetDate = Date().addingTimeInterval(7 * 24 * 3600)
-            }
-
+        let sonnetLimit: UsageLimit? = try sevenDaySonnet.flatMap { sonnet -> UsageLimit? in
+            let sonnetResetDate = try parseResetDate(
+                from: sonnet.resetsAt,
+                field: "sevenDaySonnet.resetsAt",
+                formatter: iso8601Formatter,
+                fallback: Constants.Pacing.weeklyWindow
+            )
             return UsageLimit(
                 utilization: sonnet.utilization,
                 resetAt: sonnetResetDate
@@ -99,5 +91,20 @@ extension UsageAPIResponse {
             sonnetUsage: sonnetLimit,
             lastUpdated: Date()
         )
+    }
+
+    private func parseResetDate(
+        from rawValue: String?,
+        field: String,
+        formatter: ISO8601DateFormatter,
+        fallback: TimeInterval
+    ) throws -> Date {
+        guard let rawValue else {
+            return Date().addingTimeInterval(fallback)
+        }
+        guard let date = formatter.date(from: rawValue) else {
+            throw MappingError.missingCriticalField(field: field)
+        }
+        return date
     }
 }

--- a/ClaudeMeter/Views/MenuBar/UsagePopoverView.swift
+++ b/ClaudeMeter/Views/MenuBar/UsagePopoverView.swift
@@ -32,8 +32,7 @@ struct UsagePopoverView: View {
                 }) {
                     if appModel.isRefreshing {
                         ProgressView()
-                            .scaleEffect(0.7)
-                            .frame(width: 20, height: 20)
+                            .controlSize(.small)
                     } else {
                         Image(systemName: "arrow.clockwise")
                     }

--- a/ClaudeMeterTests/UsageServiceTests.swift
+++ b/ClaudeMeterTests/UsageServiceTests.swift
@@ -181,11 +181,52 @@ final class UsageServiceTests: XCTestCase {
         assertDate(usageData.weeklyUsage.resetAt, equalsIso8601String: TestConstants.weeklyResetDateString)
     }
 
-    func test_usageFetch_withInvalidPayload_surfacesInvalidResponse() async throws {
+    func test_usageFetch_withMissingResetAt_usesFallbackWindow() async throws {
+        let responseData = try makeUsageResponseData(
+            sessionUtilization: 0,
+            weeklyUtilization: TestConstants.weeklyPercentage,
+            sessionResetAt: nil,
+            weeklyResetAt: TestConstants.weeklyResetDateString,
+            sonnetUtilization: nil,
+            sonnetResetAt: nil
+        )
+
+        let networkService = NetworkServiceStub(responseData: responseData)
+        let cacheRepository = CacheRepositoryFake()
+        let keychainRepository = KeychainRepositoryFake()
+        let settingsRepository = SettingsRepositoryFake()
+
+        let service = UsageService(
+            networkService: networkService,
+            cacheRepository: cacheRepository,
+            keychainRepository: keychainRepository,
+            settingsRepository: settingsRepository
+        )
+
+        try await keychainRepository.save(
+            sessionKey: TestConstants.sessionKeyValue,
+            account: "default"
+        )
+
+        var settings = AppSettings.default
+        settings.cachedOrganizationId = UUID(uuidString: TestConstants.organizationUUIDString)
+        try await settingsRepository.save(settings)
+
+        let usageData = try await service.fetchUsage(forceRefresh: true)
+
+        XCTAssertEqual(usageData.sessionUsage.utilization, 0)
+        XCTAssertGreaterThan(usageData.sessionUsage.resetAt.timeIntervalSinceNow, 0)
+        XCTAssertLessThanOrEqual(
+            usageData.sessionUsage.resetAt.timeIntervalSinceNow,
+            Constants.Pacing.sessionWindow + 5
+        )
+    }
+
+    func test_usageFetch_withMalformedResetAt_surfacesInvalidResponse() async throws {
         let responseData = try makeUsageResponseData(
             sessionUtilization: TestConstants.sessionPercentage,
             weeklyUtilization: TestConstants.weeklyPercentage,
-            sessionResetAt: nil,
+            sessionResetAt: "not-a-date",
             weeklyResetAt: TestConstants.weeklyResetDateString,
             sonnetUtilization: nil,
             sonnetResetAt: nil


### PR DESCRIPTION
## Summary
This consolidates the small bug-fix parts of the open PRs we reviewed:

- Fixes the null `resets_at` failure originally addressed in #18, with additional issue context from #13.
- Fixes the popover refresh spinner constraint assertion addressed in #19.

## What changed
### Null usage reset times
Claude can return `resets_at: null` for usage windows with no current consumption. The mapper previously treated that as an invalid payload and blocked refresh. This keeps `UsageLimit.resetAt` non-optional and falls back to the relevant rolling window duration while preserving hard failure for malformed non-null dates.

### Popover refresh spinner
The refresh button used `scaleEffect` plus a fixed frame around an AppKit-backed `ProgressView`, which can produce SwiftUI constraint assertions on macOS. This now uses `.controlSize(.small)` so AppKit supplies the small spinner size directly.

## Attribution
- Jean Friesewinkel: original null-reset fix in #18 and spinner sizing fix in #19.
- Rasyid Ridho: alternative null-reset fix and issue context in #13.

## Testing
- `xcodebuild test -project ClaudeMeter.xcodeproj -scheme ClaudeMeter -configuration Debug -only-testing:ClaudeMeterTests/UsageServiceTests`